### PR TITLE
Show clearer Gemini API error messages to Telegram users

### DIFF
--- a/src/bot_service.py
+++ b/src/bot_service.py
@@ -8,6 +8,7 @@ from telegram import Message
 
 from src.chat_service import ChatService
 from src.enums import TelegramBotCommands
+from src.exceptions.gemini_exceptions import GeminiUserFacingError
 from src.gemini import Gemini
 from src.services.telegram_service import TelegramService
 
@@ -90,6 +91,17 @@ class BotService:
                 message_id=processing_message.message_id,
                 text=response_text,
             )
+        except GeminiUserFacingError as exc:
+            LOGGER.warning(
+                "Gemini API error while processing Telegram message for chat_id=%s "
+                "code=%s status=%s provider_message=%s",
+                chat_id,
+                exc.code,
+                exc.status,
+                exc.provider_message,
+                exc_info=True,
+            )
+            await self._send_error_message(chat_id, processing_message, exc.user_message)
         except Exception:
             LOGGER.exception("Failed to process Telegram message for chat_id=%s", chat_id)
             await self._send_fallback_message(chat_id, processing_message)
@@ -101,15 +113,23 @@ class BotService:
         chat_id: int,
         processing_message: Message | None,
     ) -> None:
+        await self._send_error_message(chat_id, processing_message, FALLBACK_MESSAGE)
+
+    async def _send_error_message(
+        self,
+        chat_id: int,
+        processing_message: Message | None,
+        text: str,
+    ) -> None:
         try:
             if processing_message is not None:
                 await self._telegram_service.update_message(
                     chat_id=chat_id,
                     message_id=processing_message.message_id,
-                    text=FALLBACK_MESSAGE,
+                    text=text,
                 )
                 return
 
-            await self._telegram_service.send_message(chat_id=chat_id, text=FALLBACK_MESSAGE)
+            await self._telegram_service.send_message(chat_id=chat_id, text=text)
         except Exception:
-            LOGGER.exception("Failed to send fallback Telegram message for chat_id=%s", chat_id)
+            LOGGER.exception("Failed to send error Telegram message for chat_id=%s", chat_id)

--- a/src/exceptions/gemini_exceptions.py
+++ b/src/exceptions/gemini_exceptions.py
@@ -1,0 +1,49 @@
+"""User-facing Gemini API error messages."""
+
+GEMINI_RATE_LIMIT_MESSAGE = (
+    "Gemini is receiving too many requests right now. Please wait a minute and try again."
+)
+GEMINI_UNAVAILABLE_MESSAGE = (
+    "Gemini is temporarily overloaded or unavailable. Please try again shortly."
+)
+GEMINI_TIMEOUT_MESSAGE = (
+    "Gemini took too long to answer. Try a shorter message or try again shortly."
+)
+GEMINI_CONFIGURATION_MESSAGE = (
+    "I cannot reach Gemini because the bot configuration or request is invalid. "
+    "Please try again later."
+)
+GEMINI_UNEXPECTED_MESSAGE = "Gemini returned an unexpected error. Please try again later."
+
+
+class GeminiUserFacingError(Exception):
+    """Raised when a Gemini API error has a safe message for Telegram users."""
+
+    def __init__(
+        self,
+        user_message: str,
+        code: int | None = None,
+        status: str | None = None,
+        provider_message: str | None = None,
+    ):
+        self.user_message = user_message
+        self.code = code
+        self.status = status
+        self.provider_message = provider_message
+        super().__init__(user_message)
+
+
+def get_gemini_user_message(code: int | None) -> str:
+    if code == 429:
+        return GEMINI_RATE_LIMIT_MESSAGE
+
+    if code in {500, 503}:
+        return GEMINI_UNAVAILABLE_MESSAGE
+
+    if code == 504:
+        return GEMINI_TIMEOUT_MESSAGE
+
+    if code in {400, 403, 404}:
+        return GEMINI_CONFIGURATION_MESSAGE
+
+    return GEMINI_UNEXPECTED_MESSAGE

--- a/src/gemini.py
+++ b/src/gemini.py
@@ -2,10 +2,12 @@ from os import getenv
 
 import PIL.Image
 from google import genai
+from google.genai import errors
 from google.genai import types
 
 from google.genai.chats import AsyncChat, GenerateContentConfigOrDict
 from .config import Config
+from .exceptions.gemini_exceptions import GeminiUserFacingError, get_gemini_user_message
 from .plugin_manager import PluginManager
 
 
@@ -32,32 +34,48 @@ class Gemini:
         )
 
     async def send_message(self, prompt: str, chat: AsyncChat) -> str:
-        response = await chat.send_message(prompt)
-        
-        print("Function Request: " + response.__str__())
+        try:
+            response = await chat.send_message(prompt)
 
-        candidates = response.candidates or []
-        parts = candidates[0].content.parts if candidates else []
-        function_call = parts[0].function_call if parts else None
+            print("Function Request: " + response.__str__())
 
-        if not function_call:
-            return response.text
+            candidates = response.candidates or []
+            parts = candidates[0].content.parts if candidates else []
+            function_call = parts[0].function_call if parts else None
 
-        function_response = await self.__plugin_manager.get_function_response(function_call, chat)
+            if not function_call:
+                return response.text
 
-        if function_response is None or function_response.text is None:
-            return "I'm sorry, An error occurred. Please try again."
+            function_response = await self.__plugin_manager.get_function_response(function_call, chat)
 
-        print("Response: " + function_response.__str__())
+            if function_response is None or function_response.text is None:
+                return "I'm sorry, An error occurred. Please try again."
 
-        return function_response.text
+            print("Response: " + function_response.__str__())
+
+            return function_response.text
+        except errors.APIError as exc:
+            raise GeminiUserFacingError(
+                get_gemini_user_message(exc.code),
+                code=exc.code,
+                status=exc.status,
+                provider_message=exc.message,
+            ) from exc
 
 
     @staticmethod
     async def send_image(prompt: str, image: PIL.Image, chat: AsyncChat) -> str:
-        response = await chat.send_message([prompt, image])
-        print("Image response: " + response.text)
-        return response.text
+        try:
+            response = await chat.send_message([prompt, image])
+            print("Image response: " + response.text)
+            return response.text
+        except errors.APIError as exc:
+            raise GeminiUserFacingError(
+                get_gemini_user_message(exc.code),
+                code=exc.code,
+                status=exc.status,
+                provider_message=exc.message,
+            ) from exc
 
     async def close(self) -> None:
         """Close plugin-managed resources for this Gemini client instance."""

--- a/tests/unit/test_gemini_exceptions.py
+++ b/tests/unit/test_gemini_exceptions.py
@@ -1,0 +1,28 @@
+import pytest
+
+from src.exceptions.gemini_exceptions import (
+    GEMINI_CONFIGURATION_MESSAGE,
+    GEMINI_RATE_LIMIT_MESSAGE,
+    GEMINI_TIMEOUT_MESSAGE,
+    GEMINI_UNAVAILABLE_MESSAGE,
+    GEMINI_UNEXPECTED_MESSAGE,
+    get_gemini_user_message,
+)
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_message"),
+    [
+        (429, GEMINI_RATE_LIMIT_MESSAGE),
+        (500, GEMINI_UNAVAILABLE_MESSAGE),
+        (503, GEMINI_UNAVAILABLE_MESSAGE),
+        (504, GEMINI_TIMEOUT_MESSAGE),
+        (400, GEMINI_CONFIGURATION_MESSAGE),
+        (403, GEMINI_CONFIGURATION_MESSAGE),
+        (404, GEMINI_CONFIGURATION_MESSAGE),
+        (418, GEMINI_UNEXPECTED_MESSAGE),
+        (None, GEMINI_UNEXPECTED_MESSAGE),
+    ],
+)
+def test_get_gemini_user_message_maps_api_codes(code, expected_message):
+    assert get_gemini_user_message(code) == expected_message

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -4,6 +4,11 @@ from types import SimpleNamespace
 from fastapi.testclient import TestClient
 
 from src.bot_service import FALLBACK_MESSAGE, PROCESSING_MESSAGE, UNSUPPORTED_MESSAGE
+from src.exceptions.gemini_exceptions import (
+    GEMINI_RATE_LIMIT_MESSAGE,
+    GEMINI_UNAVAILABLE_MESSAGE,
+    GeminiUserFacingError,
+)
 from src.main import create_app
 from src.services.database_service import get_db
 
@@ -88,8 +93,14 @@ class FakeChatService:
 
 
 class FakeGemini:
-    def __init__(self, *, fail: bool = False):
+    def __init__(
+        self,
+        *,
+        fail: bool = False,
+        user_error: GeminiUserFacingError | None = None,
+    ):
         self.fail = fail
+        self.user_error = user_error
         self.closed = False
         self.chat_histories: list[list[dict]] = []
         self.prompts: list[str] = []
@@ -101,6 +112,8 @@ class FakeGemini:
 
     async def send_message(self, prompt: str, chat) -> str:
         self.prompts.append(prompt)
+        if self.user_error is not None:
+            raise self.user_error
         if self.fail:
             raise RuntimeError("boom")
         return f"reply:{prompt}"
@@ -108,6 +121,8 @@ class FakeGemini:
     async def send_image(self, prompt: str, image, chat) -> str:
         self.prompts.append(prompt)
         self.images.append(image)
+        if self.user_error is not None:
+            raise self.user_error
         return f"image:{prompt}"
 
     async def close(self) -> None:
@@ -120,13 +135,18 @@ class FakeGemini:
         await self.close()
 
 
-def build_test_client(*, secure_enabled: bool = False, gemini_fail: bool = False):
+def build_test_client(
+    *,
+    secure_enabled: bool = False,
+    gemini_fail: bool = False,
+    gemini_user_error: GeminiUserFacingError | None = None,
+):
     telegram_service = FakeTelegramService(secure_enabled=secure_enabled)
     chat_service = FakeChatService()
     gemini_instances: list[FakeGemini] = []
 
     def gemini_factory() -> FakeGemini:
-        gemini = FakeGemini(fail=gemini_fail)
+        gemini = FakeGemini(fail=gemini_fail, user_error=gemini_user_error)
         gemini_instances.append(gemini)
         return gemini
 
@@ -266,5 +286,53 @@ def test_processing_failure_updates_message_with_fallback():
     assert response.text == "OK"
     assert telegram_service.sent_messages == [(12, PROCESSING_MESSAGE)]
     assert telegram_service.updated_messages == [(12, 1, FALLBACK_MESSAGE)]
+    assert chat_service.add_calls == []
+    assert len(gemini_instances) == 1
+
+
+def test_gemini_503_updates_message_with_unavailable_message():
+    client, telegram_service, chat_service, gemini_instances = build_test_client(
+        gemini_user_error=GeminiUserFacingError(
+            GEMINI_UNAVAILABLE_MESSAGE,
+            code=503,
+            status="UNAVAILABLE",
+            provider_message="The model is overloaded.",
+        )
+    )
+
+    with client:
+        response = client.post(
+            "/webhook",
+            json={"message": {"chat_id": 13, "text": "hello", "date": "2026-01-15T10:30:00"}},
+        )
+
+    assert response.status_code == 200
+    assert response.text == "OK"
+    assert telegram_service.sent_messages == [(13, PROCESSING_MESSAGE)]
+    assert telegram_service.updated_messages == [(13, 1, GEMINI_UNAVAILABLE_MESSAGE)]
+    assert chat_service.add_calls == []
+    assert len(gemini_instances) == 1
+
+
+def test_gemini_429_updates_message_with_rate_limit_message():
+    client, telegram_service, chat_service, gemini_instances = build_test_client(
+        gemini_user_error=GeminiUserFacingError(
+            GEMINI_RATE_LIMIT_MESSAGE,
+            code=429,
+            status="RESOURCE_EXHAUSTED",
+            provider_message="Rate limit exceeded.",
+        )
+    )
+
+    with client:
+        response = client.post(
+            "/webhook",
+            json={"message": {"chat_id": 14, "text": "hello", "date": "2026-01-15T10:30:00"}},
+        )
+
+    assert response.status_code == 200
+    assert response.text == "OK"
+    assert telegram_service.sent_messages == [(14, PROCESSING_MESSAGE)]
+    assert telegram_service.updated_messages == [(14, 1, GEMINI_RATE_LIMIT_MESSAGE)]
     assert chat_service.add_calls == []
     assert len(gemini_instances) == 1


### PR DESCRIPTION
## Summary
- add Gemini API error mapping with clear, user-facing Telegram messages
- translate `google.genai.errors.APIError` into a safe domain exception
- keep unexpected failures on the existing generic fallback path

## Tests
- `pytest tests/unit/test_main.py tests/unit/test_gemini_exceptions.py`
- `pytest`

Closes #33